### PR TITLE
Added Remember Singapore under history list

### DIFF
--- a/_posts/2014-03-15-connections.markdown
+++ b/_posts/2014-03-15-connections.markdown
@@ -84,6 +84,7 @@ category: index
 * [ghetto singapore](http://www.ghettosingapore.com/category/singapore/heritage-places/)
 * [GIC history](http://gichistory.gic.com.sg/)
 * [Your Familiar Stranger](http://www.yourfamiliarstranger.org/)
+* [Remember Singapore](https://remembersingapore.org)
 
 ### nature
 * [Animal and Plants of Singapore](http://nathist.science.nus.edu.sg/)


### PR DESCRIPTION
It has extensive details about various historical tidbits such as what roads used to be called in dialects.
